### PR TITLE
Add GitHub Actions release workflow to fix zip packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build zip
+        run: |
+          mkdir -p /tmp/build/cornerstone
+          rsync -r \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='SECURITY.md' \
+            . /tmp/build/cornerstone/
+          cd /tmp/build
+          zip -r cornerstone.zip cornerstone/
+
+      - name: Attach zip to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: /tmp/build/cornerstone.zip


### PR DESCRIPTION
## Summary

Fixes #5 — releases 1.0.9 and 1.1.0 contained an absolute path from the build machine (`var/www/html/wp-content/themes/cornerstone-main/`) alongside the correct `cornerstone-main/` directory, doubling the zip size and breaking installation.

The root cause was manual packaging. This workflow automates it:

- Triggers on every published GitHub release
- Checks out a clean copy of the repo
- Uses `rsync` to assemble the theme into a `cornerstone/` directory, excluding `.git`, `.github`, and `SECURITY.md`
- Zips it and attaches `cornerstone.zip` to the release

Future releases will produce a clean, correctly structured zip with no stale or machine-specific files.

## Test plan

- [ ] Publish a test release (or re-publish 1.1.0) and confirm the workflow runs
- [ ] Download the attached `cornerstone.zip` and verify it contains only a single `cornerstone/` directory with the expected theme files
- [ ] Install the zip via WordPress Admin > Appearance > Themes > Add New > Upload

https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE)_