### PR TITLE
Scope ActivityPub content template filter to Jetpack Social Notes only

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -129,6 +129,12 @@ function cornerstone_webmention_discovery() {
 }
 add_action('wp_head', 'cornerstone_webmention_discovery');
 
+// Strip the title wrapper from ActivityPub payloads so Social Notes don't
+// duplicate their text on Mastodon (the hidden post title was being prepended).
+add_filter('activitypub_object_content_template', function($template) {
+    return '[ap_content]';
+}, 10, 1);
+
 // Customize excerpt length
 function cornerstone_excerpt_length($length) {
     return 30;

--- a/functions.php
+++ b/functions.php
@@ -131,9 +131,12 @@ add_action('wp_head', 'cornerstone_webmention_discovery');
 
 // Strip the title wrapper from ActivityPub payloads so Social Notes don't
 // duplicate their text on Mastodon (the hidden post title was being prepended).
-add_filter('activitypub_object_content_template', function($template) {
-    return '[ap_content]';
-}, 10, 1);
+add_filter('activitypub_object_content_template', function($template, $object, $post) {
+    if ($post && $post->post_type === 'sn') {
+        return '[ap_content]';
+    }
+    return $template;
+}, 10, 3);
 
 // Customize excerpt length
 function cornerstone_excerpt_length($length) {


### PR DESCRIPTION
## Summary

Adds an `activitypub_object_content_template` filter to strip the hidden title wrapper from ActivityPub payloads, but only for Jetpack Social Notes (`sn` post type). This prevents Social Notes from duplicating their text on Mastodon.

Standard blog posts, pages, and all other post types are unaffected.

## Test plan

- [ ] Publish a Jetpack Social Note and confirm the text appears once on Mastodon (not duplicated)
- [ ] Publish a standard blog post and confirm its ActivityPub payload is unchanged

https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE)_