### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.2] - 2026-07-02
+
+### Fixed
+- Jetpack Social Notes no longer duplicate their text on Mastodon; the hidden title string is no longer prepended to the ActivityPub payload
+
+### Changed
+- `activitypub_object_content_template` filter scoped to `sn` post type only — standard posts, pages, and all other content types are unaffected
+
 ## [1.1.1] - 2026-05-20
 
 ### Fixed

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Cornerstone
 Description: A WordPress theme for the IndieWeb with microformats2, ActivityPub, and Webmentions support. Built on the principle that you own your digital home.
-Version: 1.1.1
+Version: 1.1.2
 Author: Khurt Williams
 License: GPL v2 or later
 


### PR DESCRIPTION
Bumps `style.css` version to 1.1.2 and updates `CHANGELOG.md` to document the Social Notes ActivityPub fix from PR #9.

https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE)_