### PR TITLE
Revert ActivityPub content template filter

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -129,15 +129,6 @@ function cornerstone_webmention_discovery() {
 }
 add_action('wp_head', 'cornerstone_webmention_discovery');
 
-// Strip the title wrapper from ActivityPub payloads so Social Notes don't
-// duplicate their text on Mastodon (the hidden post title was being prepended).
-add_filter('activitypub_object_content_template', function($template, $object, $post) {
-    if ($post && $post->post_type === 'sn') {
-        return '[ap_content]';
-    }
-    return $template;
-}, 10, 3);
-
 // Customize excerpt length
 function cornerstone_excerpt_length($length) {
     return 30;


### PR DESCRIPTION
Removes the `activitypub_object_content_template` filter added in PR #9. The filter broke all federation (both Social Notes and regular blog posts stopped appearing on Mastodon and Bluesky) under ActivityPub plugin v9.0.2. The hook likely behaves differently in v9.x than assumed. Reverting to restore federation while the correct approach for v9.0.2 is investigated.

https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE)_