### PR TITLE
Bump version to 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.3] - 2026-07-02
+
+### Reverted
+- Removed `activitypub_object_content_template` filter introduced in 1.1.2; it did not fix Social Note duplication and caused all federation to be delayed; correct approach for ActivityPub v9.x is still under investigation
+
 ## [1.1.2] - 2026-07-02
 
 ### Fixed

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Cornerstone
 Description: A WordPress theme for the IndieWeb with microformats2, ActivityPub, and Webmentions support. Built on the principle that you own your digital home.
-Version: 1.1.2
+Version: 1.1.3
 Author: Khurt Williams
 License: GPL v2 or later
 


### PR DESCRIPTION
Bumps version to 1.1.3 — functionally identical to 1.1.1. Documents the revert of the broken 1.1.2 ActivityPub filter in the changelog.

https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE)_