### PR TITLE
Harden output escaping (security review findings)

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -60,7 +60,7 @@ function cornerstone_comment($comment, $args, $depth) {
                 <div class="comment-metadata">
                     <span class="fn p-name"><?php echo get_comment_author_link(); ?></span>
                     <a href="<?php echo esc_url(get_comment_link($comment->comment_ID)); ?>" class="u-url">
-                        <time class="dt-published" datetime="<?php echo get_comment_date('c'); ?>">
+                        <time class="dt-published" datetime="<?php echo esc_attr(get_comment_date('c')); ?>">
                             <?php printf(__('%1$s at %2$s', 'cornerstone'), get_comment_date(), get_comment_time()); ?>
                         </time>
                     </a>

--- a/header.php
+++ b/header.php
@@ -78,9 +78,9 @@
             </a>
         </h1>
         
-        <?php $description = get_bloginfo('description', 'display'); ?>
+        <?php $description = get_bloginfo('description', 'raw'); ?>
         <?php if ($description || is_customize_preview()) : ?>
-            <p class="site-description"><?php echo $description; ?></p>
+            <p class="site-description"><?php echo esc_html($description); ?></p>
         <?php endif; ?>
     </div>
 </div>

--- a/single.php
+++ b/single.php
@@ -62,7 +62,7 @@
                         echo '<div class="post-categories">';
                         echo '<span>' . __('Categories:', 'cornerstone') . ' </span>';
                         foreach ($categories as $category) {
-                            echo '<a href="' . get_category_link($category->term_id) . '" class="p-category" rel="category tag">' . $category->name . '</a> ';
+                            echo '<a href="' . esc_url(get_category_link($category->term_id)) . '" class="p-category" rel="category tag">' . esc_html($category->name) . '</a> ';
                         }
                         echo '</div>';
                     }
@@ -72,7 +72,7 @@
                         echo '<div class="post-tags">';
                         echo '<span>' . __('Tags:', 'cornerstone') . ' </span>';
                         foreach ($tags as $tag) {
-                            echo '<a href="' . get_tag_link($tag->term_id) . '" class="p-category" rel="tag">' . $tag->name . '</a> ';
+                            echo '<a href="' . esc_url(get_tag_link($tag->term_id)) . '" class="p-category" rel="tag">' . esc_html($tag->name) . '</a> ';
                         }
                         echo '</div>';
                     }
@@ -216,14 +216,14 @@
                             <article class="related-post h-entry">
                                 <?php if (has_post_thumbnail($related->ID)) : ?>
                                     <div class="related-post-thumbnail">
-                                        <a href="<?php echo get_permalink($related->ID); ?>" class="u-url">
+                                        <a href="<?php echo esc_url(get_permalink($related->ID)); ?>" class="u-url">
                                             <?php echo get_the_post_thumbnail($related->ID, 'related-post-thumb', array('class' => 'u-photo')); ?>
                                         </a>
                                     </div>
                                 <?php endif; ?>
                                 <h4 class="related-post-title p-name">
-                                    <a href="<?php echo get_permalink($related->ID); ?>" class="u-url">
-                                        <?php echo get_the_title($related->ID); ?>
+                                    <a href="<?php echo esc_url(get_permalink($related->ID)); ?>" class="u-url">
+                                        <?php echo esc_html(get_the_title($related->ID)); ?>
                                     </a>
                                 </h4>
                                 <div class="related-post-date">
@@ -254,18 +254,18 @@
                     <div class="nav-links">
                         <?php if ($prev_post) : ?>
                             <div class="nav-previous">
-                                <a href="<?php echo get_permalink($prev_post->ID); ?>" rel="prev">
+                                <a href="<?php echo esc_url(get_permalink($prev_post->ID)); ?>" rel="prev">
                                     <span class="nav-subtitle"><?php _e('Previous Post', 'cornerstone'); ?></span>
-                                    <span class="nav-title"><?php echo get_the_title($prev_post->ID); ?></span>
+                                    <span class="nav-title"><?php echo esc_html(get_the_title($prev_post->ID)); ?></span>
                                 </a>
                             </div>
                         <?php endif; ?>
-                        
+
                         <?php if ($next_post) : ?>
                             <div class="nav-next">
-                                <a href="<?php echo get_permalink($next_post->ID); ?>" rel="next">
+                                <a href="<?php echo esc_url(get_permalink($next_post->ID)); ?>" rel="next">
                                     <span class="nav-subtitle"><?php _e('Next Post', 'cornerstone'); ?></span>
-                                    <span class="nav-title"><?php echo get_the_title($next_post->ID); ?></span>
+                                    <span class="nav-title"><?php echo esc_html(get_the_title($next_post->ID)); ?></span>
                                 </a>
                             </div>
                         <?php endif; ?>


### PR DESCRIPTION
## Summary

Fixes 5 of 6 findings from a security review of the theme templates. All are defense-in-depth escaping gaps — none are currently exploitable without a misbehaving plugin, but WordPress coding standards require escaping at the point of output regardless of the source.

- `header.php` — site tagline now passed through `esc_html()`; switched from `'display'` to `'raw'` filter on `get_bloginfo('description')` to avoid double-encoding entities
- `single.php` — related post links/titles, post navigation links/titles, and category/tag links/names now wrapped in `esc_url()` / `esc_html()`
- `comments.php` — comment date now wrapped in `esc_attr()` before being placed in the `datetime` attribute

## Not included

A 6th finding — the Font Awesome CDN stylesheet (`functions.php`) is loaded without a Subresource Integrity (SRI) hash — is **not** fixed in this PR. Computing the correct hash requires fetching the file from `cdnjs.cloudflare.com`, which this environment's network policy blocks. Adding a guessed or stale hash would make browsers refuse to load the stylesheet, breaking every icon on the site. This needs to be done from an environment with access to cdnjs, or by self-hosting the Font Awesome file.

## Test plan

- [ ] Confirm site tagline still displays correctly under Settings > General
- [ ] Confirm related posts, post navigation, and category/tag links on single post pages still work and render correctly
- [ ] Confirm comment timestamps still display correctly

https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE)_