### PR TITLE
Add SRI hash to Font Awesome CDN stylesheet

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -68,6 +68,8 @@ function cornerstone_scripts() {
     $theme = wp_get_theme();
     wp_enqueue_style('cornerstone-style', get_stylesheet_uri(), array(), $theme->get('Version'));
     wp_enqueue_style('font-awesome', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css', array(), '6.6.0');
+    wp_style_add_data('font-awesome', 'integrity', 'sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg==');
+    wp_style_add_data('font-awesome', 'crossorigin', 'anonymous');
     wp_enqueue_script('cornerstone-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '1.0', true);
 
     if (is_singular() && comments_open() && get_option('thread_comments')) {


### PR DESCRIPTION
## Summary

Completes the 6th finding from the earlier security review (PR #13). Adds a Subresource Integrity (SRI) hash to the Font Awesome CDN stylesheet so the browser refuses to load it if the CDN ever serves tampered or unexpected content.

- `functions.php`: `wp_style_add_data()` sets `integrity` (SHA-512) and `crossorigin="anonymous"` on the `font-awesome` style handle

The hash was computed from `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css` outside this environment, since `cdnjs.cloudflare.com` is blocked by this sandbox's network policy.

## Test plan

- [ ] Confirm Font Awesome icons still render correctly across the site (social icons, ActivityPub reactions, etc.)
- [ ] Confirm the `<link>` tag for font-awesome includes `integrity` and `crossorigin` attributes in page source

https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkXzcf1BsZV8affwyr36mE)_